### PR TITLE
Update how-diffusion-models-work.md

### DIFF
--- a/src/blog/w/how-diffusion-models-work.md
+++ b/src/blog/w/how-diffusion-models-work.md
@@ -52,7 +52,7 @@
 
 在实践中，它们是用一个马尔科夫链的 $T$ 步骤来制定的。这里，马尔可夫链意味着每一步只取决于前一步，这是一个很自然的假设。重要的是，与基于流量的模型不同，我们不受限制地使用特定类型的神经网络。
 
-给定一个数据点 $\mathbf{x}_0$ ，从真实数据分布 $q(\mathbf{x})$ ($\mathbf{x}_0 \sim q(\mathbf{x})$) 中采样，我们可以通过添加噪声来定义一个前向扩散过程。具体来说，在马尔科夫链的每一步，我们添加方差为 $\beta_t$ 到 $\mathbf{x}_{t-1}$ 的高斯噪声，产生一个新的潜在变量 $\mathbf{x}_{t}$ ，其分布为 $q(\mathbf{x}_t|\mathbf{x}_{t-1})$ 。这个扩散过程可以表述如下：
+给定一个数据点 $\mathbf{x}_0$ ，从真实数据分布 $q(\mathbf{x})$ ($\mathbf{x}_0 \sim q(\mathbf{x})$) 中采样，我们可以通过添加噪声来定义一个前向扩散过程。具体来说，在马尔科夫链的每一步，我们向 $\mathbf{x}_{t-1}$ 添加方差为 $\beta_t$ 的高斯噪声，产生一个新的潜在变量 $\mathbf{x}_{t}$ ，其分布为 $q(\mathbf{x}_t|\mathbf{x}_{t-1})$ 。这个扩散过程可以表述如下：
 
 $$
 q(\mathbf{x}_t \vert \mathbf{x}_{t-1}) = \mathcal{N}(\mathbf{x}_t; \boldsymbol{\mu}_t=\sqrt{1 - \beta_t} \mathbf{x}_{t-1}, \boldsymbol{\Sigma}_t = \beta_t\mathbf{I})
@@ -91,7 +91,7 @@ $$
 
 &=\sqrt{1 - \beta_t} \mathbf{x}_{t-1} + \sqrt{\beta_t}\boldsymbol{\epsilon}_{t-1}\\
 
-&= \sqrt{\alpha_t}\mathbf{x}_{t-2} + \sqrt{1 - \alpha_t}\boldsymbol{\epsilon}_{t-2}  \\
+&= \sqrt{\alpha_t}\mathbf{x}_{t-1} + \sqrt{1 - \alpha_t}\boldsymbol{\epsilon}_{t-1}  \\
 
 &= \dots \\
 
@@ -153,7 +153,7 @@ $$
 
 :::
 
-如果我们对所有的时间步数应用反向公式 $p_\theta(\mathbf{x}_{0:T})$ ，我们可以从 $\mathbf{x}_T$ 到数据分布：
+如果我们对所有的时间步数应用反向公式 $p_\theta(\mathbf{x}_{0:T})$ ，我们可以由 $\mathbf{x}_T$ 得到数据分布：
 
 $$
 p_\theta(\mathbf{x}_{0:T}) = p_{\theta}(\mathbf{x}_T) \prod^T_{t=1} p_\theta(\mathbf{x}_{t-1} \vert \mathbf{x}_t)
@@ -181,7 +181,7 @@ $$
 
 我们来分析一下这些内容：
 
-1. $\mathbb{E}_{q(x_1 \vert x_0)} [log p_{\theta} (\mathbf{x}_0 \vert \mathbf{x}_1)]$ 可以当作是一个重建项 (reconstruction term) ，类似于变量自动编码器 ELBO 中的一个。在 [Ho et al 2020](https://arxiv.org/abs/2006.11239) 的研究中，这个术语是用一个单独的解码器学习的。
+1. $\mathbb{E}_{q(x_1 \vert x_0)} [log p_{\theta} (\mathbf{x}_0 \vert \mathbf{x}_1)]$ 可以当作是一个重建项 (reconstruction term) ，类似于变量自动编码器 ELBO 中的那个。在 [Ho et al 2020](https://arxiv.org/abs/2006.11239) 的研究中，这一项是用一个单独的解码器学习的。
 2. $D_{KL}(q(\mathbf{x}_T \vert \mathbf{x}_0) \vert\vert p(\mathbf{x}_T))$ 显示了 $\mathbf{x}_T$ 与标准高斯是多么的相似。注意到，整个项都没有可训练的参数，因此，训练过程这个项会被忽略。
 3. 最后的第三项 $\sum_{t=2}^T L_{t-1}$ 也表示为 $L_t$ ，描述了期望的去噪步骤 $p_{\theta}(\mathbf{x}_{t-1} \vert \mathbf{x}_t))$ 与近似项 $q(\mathbf{x}_{t-1} \vert \mathbf{x}_t, \mathbf{x}_0)$ 之间的差异。
 


### PR DESCRIPTION
修改了一些表述，使其更为通顺且贴合原文本意。其中重参数采样的公式部分修正了原文作者在该处存在typo（下标错误）。